### PR TITLE
🐛 fix trimming

### DIFF
--- a/src/Maui.Health/Platforms/Android/HealthServiceAndroid.cs
+++ b/src/Maui.Health/Platforms/Android/HealthServiceAndroid.cs
@@ -118,7 +118,14 @@ public partial class HealthService
         }
     }
 
-    public async partial Task<List<TDto>> GetHealthDataAsync<TDto>(HealthTimeRange timeRange, CancellationToken cancellationToken)
+    // Public generic method without async/await to avoid async state machine generation
+    public partial Task<List<TDto>> GetHealthDataAsync<TDto>(HealthTimeRange timeRange, CancellationToken cancellationToken)
+        where TDto : HealthMetricBase
+    {
+        return GetHealthDataCoreAsync<TDto>(timeRange, cancellationToken);
+    }
+
+    private async Task<List<TDto>> GetHealthDataCoreAsync<TDto>(HealthTimeRange timeRange, CancellationToken cancellationToken)
         where TDto : HealthMetricBase
     {
         try

--- a/src/Maui.Health/Platforms/iOS/HealthServiceiOS.cs
+++ b/src/Maui.Health/Platforms/iOS/HealthServiceiOS.cs
@@ -111,7 +111,15 @@ public partial class HealthService
         return new();
     }
 
-    public async partial Task<List<TDto>> GetHealthDataAsync<TDto>(HealthTimeRange timeRange, CancellationToken cancellationToken)
+    // Public generic method without async/await to avoid async state machine generation
+    public partial Task<List<TDto>> GetHealthDataAsync<TDto>(HealthTimeRange timeRange, CancellationToken cancellationToken)
+        where TDto : HealthMetricBase
+    {
+        return GetHealthDataCoreAsync<TDto>(timeRange, cancellationToken);
+    }
+
+    // Private helper retains async/await, but is not the public generic API the linker trips on
+    private async Task<List<TDto>> GetHealthDataCoreAsync<TDto>(HealthTimeRange timeRange, CancellationToken cancellationToken)
         where TDto : HealthMetricBase
     {
         if (!IsSupported)


### PR DESCRIPTION
@Kebechet 

I fixed the ILLinker crash by removing the async state machine on the public generic method.
What changed:
 - Refactored GetHealthDataAsync<TDto> on iOS and Android to return a Task from a private async helper:
 - iOS: GetHealthDataAsync<TDto> now delegates to GetHealthDataCoreAsync<TDto>
 - Android: GetHealthDataAsync<TDto> now delegates to GetHealthDataCoreAsync<TDto>
Why:
 - The linker crash referenced HealthService/<GetHealthDataAsync>d__12 which is the compiler-generated async state machine for the generic method. Returning the inner task avoids generating that state machine and prevents the trimmer error without using broad preserves.

fixxes the following error when building in release mode with trimming:

```
>C:\Program Files\dotnet\packs\Microsoft.iOS.Windows.Sdk.net10.0_26.1\26.1.10494\tools\msbuild\iOS\Xamarin.iOS.Common.After.targets(387,3): error IL1012: IL Trimmer has encountered an unexpected error. Please report the issue at https://aka.ms/report-illink
2>  Fatal error in IL Linker
2>  Unhandled exception. System.Collections.Generic.KeyNotFoundException: The given key 'Maui.Health.Services.HealthService/<GetHealthDataAsync>d__12`1' was not present in the dictionary.
2>     at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
2>     at Mono.Linker.Dataflow.CompilerGeneratedState.<GetCompilerGeneratedStateForType>g__MapGeneratedTypeTypeParameters|11_2(TypeDefinition generatedType, Dictionary`2 generatedTypeToTypeArgs, LinkContext context)
2>     at Mono.Linker.Dataflow.CompilerGeneratedState.<GetCompilerGeneratedStateForType>g__MapGeneratedTypeTypeParameters|11_2(TypeDefinition generatedType, Dictionary`2 generatedTypeToTypeArgs, LinkContext context)
2>     at Mono.Linker.Dataflow.CompilerGeneratedState.GetCompilerGeneratedStateForType(TypeDefinition type)
2>     at Mono.Linker.Dataflow.CompilerGeneratedState.TryGetCompilerGeneratedCalleesForUserMethod(MethodDefinition method, List`1& callees)
2>     at Mono.Linker.Steps.MarkStep.MarkReflectionLikeDependencies(MethodIL methodIL, Boolean requiresReflectionMethodBodyScanner, MessageOrigin origin)
2>     at Mono.Linker.Steps.MarkStep.MarkMethodBody(MethodBody body, MessageOrigin origin)
2>     at Mono.Linker.Steps.MarkStep.ProcessMethod(MethodDefinition method, DependencyInfo& reason)
2>     at Mono.Linker.Steps.MarkStep.ProcessQueue()
2>     at Mono.Linker.Steps.MarkStep.ProcessPrimaryQueue()
2>     at Mono.Linker.Steps.MarkStep.Process()
2>     at Mono.Linker.Steps.MarkStep.Process(LinkContext context)
2>     at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step)
2>     at Mono.Linker.Pipeline.Process(LinkContext context)
2>     at Mono.Linker.Driver.Run(ILogger customLogger)
2>     at Mono.Linker.Driver.Main(String[] args)
2>C:\Program Files\dotnet\packs\Microsoft.iOS.Windows.Sdk.net10.0_26.1\26.1.10494\tools\msbuild\iOS\Xamarin.iOS.Common.After.targets(432,3): error MSB3371: The file "obj\Release\net10.0-ios\iossimulator-arm64\linked\Link.semaphore" cannot be created. Could not find a part of the path 'C:\Dev\Maui.Health\demo\DemoApp\DemoApp\obj\Release\net10.0-ios\iossimulator-arm64\linked\Link.semaphore'.
```

Resolved #7 and #3 